### PR TITLE
User readable message on permission error in tmp directory

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -29,6 +29,9 @@ steps.all({
 	extractPath: EXTRACT_PATH,
 	targetPath: targetPath
 }).then(console.log).catch(function (err) {
+  if(err.code === 'EACCES') {
+    console.log('Permission was denied on ' + err.path + ' directory for downloading perk files');
+  }
 	if (err.hasOwnProperty(message) && err.hasOwnProperty(err.code)) {
 		var _message = err.message;
 		if (err.code !== 0) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -29,9 +29,9 @@ steps.all({
 	extractPath: EXTRACT_PATH,
 	targetPath: targetPath
 }).then(console.log).catch(function (err) {
-  if(err.code === 'EACCES') {
-    console.log('Permission was denied on ' + err.path + ' directory for downloading perk files');
-  }
+	if (err.code === 'EACCES') {
+		console.log('Permission was denied on ' + err.path + ' directory for downloading perk files');
+	}
 	if (err.hasOwnProperty(message) && err.hasOwnProperty(err.code)) {
 		var _message = err.message;
 		if (err.code !== 0) {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "devDependencies": {
     "babel-cli": "^6.5.1",
     "babel-preset-es2015": "^6.5.0",
+    "babel-register": "^6.16.3",
     "chai": "^3.5.0",
     "chai-as-promised": "^5.3.0",
     "mocha": "^2.4.5"

--- a/src/index.js
+++ b/src/index.js
@@ -30,6 +30,9 @@ steps.all({
 })
 .then(console.log)
 .catch(err => {
+  if(err.code === 'EACCES') {
+    console.log('Permission was denied on ' + err.path + ' directory for downloading perk files');
+  }
 	if(err.hasOwnProperty(message) && err.hasOwnProperty(err.code)) {
 		let message = err.message;
 		if(err.code !== 0) {

--- a/src/index.js
+++ b/src/index.js
@@ -30,9 +30,9 @@ steps.all({
 })
 .then(console.log)
 .catch(err => {
-  if(err.code === 'EACCES') {
-    console.log('Permission was denied on ' + err.path + ' directory for downloading perk files');
-  }
+	if(err.code === 'EACCES') {
+		console.log('Permission was denied on ' + err.path + ' directory for downloading perk files');
+	}
 	if(err.hasOwnProperty(message) && err.hasOwnProperty(err.code)) {
 		let message = err.message;
 		if(err.code !== 0) {


### PR DESCRIPTION
closes #1 
Not sure how to test for this other than writing some manual script. 

Maybe have a fixture folder with bad permissions that we mock as `TMP` when we run the test?
